### PR TITLE
fix alternate rows are showing in white

### DIFF
--- a/css/Core.Table.css
+++ b/css/Core.Table.css
@@ -213,6 +213,10 @@ table tr.MasterAction {
     background-color: #333;
 }
 
+.DataTable tr:nth-child(odd) td {
+    background-color: #1f1f1f
+}
+
 .DataTable tr:nth-child(even) td {
     background-color: #242424;
 }


### PR DESCRIPTION
this fixes https://github.com/relkai/otobo-dark-skin/issues/2