### PR TITLE
Update README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,11 @@
+# Workflow syntax for GitHub Actions
+# This workflow is used to generate a OPM (OTOBO Package Manager) installation file which can be installed in the OTOBO admin frontend 
+# To enable the creation of the release you may have to set the `Read and write permissions` in the `Workflow permissions` (Project Settings > Actions > General)
+# Feel free to use it in other OTOBO plugin projects 
+#
+# This file was initially generated for the project https://github.com/Micke90s/OTOBO-Example-Agent-Skin
+# Please keep this reference if used in other projects. 
+
 name: Release
 run-name: Release ${{ github.repository }} - ${{ github.ref }}
 on:
@@ -56,6 +64,7 @@ jobs:
              OPMFILE=$(basename $(ls -t ./build/*.opm | head -n2 ) )
              echo "ARTIFACT_PATH=./build/${OPMFILE}" >> $GITHUB_OUTPUT
              echo "ARTIFACT_NAME=${OPMFILE}" >> $GITHUB_OUTPUT
+             sed -i "s/<BuildHost>yourhost.example.com<\/BuildHost>/<BuildHost>github.com<\/BuildHost>/g" ./build/${OPMFILE}
       # Release
       - name: Create release
         id: create_release

--- a/Kernel/Config/Files/XML/OtoboDarkSkin.xml
+++ b/Kernel/Config/Files/XML/OtoboDarkSkin.xml
@@ -12,5 +12,17 @@
       </Hash>
     </Value>
   </Setting>
+  <Setting Name="AgentLogoCustom###OtoboDarkSkin" Required="0" Valid="0">
+    <Description Translatable="1">The logo shown in the header of the agent interface for the skin "OtoboDarkSkin". See "AgentLogo" for further description.</Description>
+    <Navigation>Frontend::Agent</Navigation>
+    <Value>
+      <Hash>
+        <Item Key="URL">skins/Agent/default/img/logo_bg.png</Item>
+        <Item Key="StyleTop">7px</Item>
+        <Item Key="StyleRight">24px</Item>
+        <Item Key="StyleHeight">55px</Item>
+        <Item Key="StyleWidth">300px</Item>
+      </Hash>
+    </Value>
+  </Setting>  
 </otobo_config>
-

--- a/OtoboDarkSkin.sopm
+++ b/OtoboDarkSkin.sopm
@@ -41,6 +41,7 @@
     <File Permission="660" Location="var/httpd/htdocs/skins/Agent/OtoboDarkSkin/css/Core.Responsive.css" />
     <File Permission="660" Location="var/httpd/htdocs/skins/Agent/OtoboDarkSkin/css/Core.Table.css" />
     <File Permission="660" Location="var/httpd/htdocs/skins/Agent/OtoboDarkSkin/css/Core.TicketDetail.css" />
+    <File Permission="660" Location="var/httpd/htdocs/skins/Agent/OtoboDarkSkin/css/Core.Tooltip.css" />    
     <File Permission="660" Location="var/httpd/htdocs/skins/Agent/OtoboDarkSkin/css/Core.Widget.css" />
     <File Permission="660" Location="var/httpd/htdocs/skins/Agent/OtoboDarkSkin/css/Core.WidgetMenu.css" />
     <File Permission="660" Location="var/httpd/htdocs/skins/Agent/OtoboDarkSkin/css/FAQ.Agent.Default.css" />

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A dark skin for OTOBO
 
 OTOBO is a fork based on the ((OTRS)) Community Edition.
 
-https://otobo.de
+- https://otobo.de
+- https://github.com/RotherOSS/otobo
 
 ## Motivation
 At the time of this release, only one default skin is included in OTOBO, and the colors used there are way too bright and shiny for me personally. So I decided to create a dark skin for OTOBO based on the files included in the default skin.
@@ -15,54 +16,19 @@ It's possible that it doesn't work well with all add-on packages, since I focuse
 - Survey
 
 ## Installation
-Copy the files of this repository to ```$OTOBO_HOME/var/httpd/htdocs/skins/Agent/otobo-dark-skin``` and adjust the permissions.
+### OTOBO Package Manager
+The skin plugin can be installed using the `OTOBO Package Manager` (Admin > Administration > Package Manager). 
+Please download the `OPM` file from [Releases](https://github.com/relkai/otobo-dark-skin/releases) and install it using the `Install Package` button.
 
-**Example:**
-```
-chown -R otobo:www-data $OTOBO_HOME/var/httpd/htdocs/skins/Agent/otobo-dark-skin
-```
+### OTOBO System configuration 
+OTOBO offers a powerfull `System configuration` (Admin > Administration > System configuration) to change the behavior of the frontend. 
 
-Then create the file ```$OTOBO_HOME/Kernel/Config/Files/XML/CustomSkin.xml``` with the following contents:
-```
-<?xml version="1.0" encoding="utf-8" ?>
-<otobo_config version="2.0" init="Application">
-        <Setting Name="AgentLogoCustom###otobo-dark-skin" Required="0" Valid="1">
-                <Description Translatable="1">The logo shown in the header of the agent interface for the skin "OTOBO Dark". See "AgentLogo" for further description.</Description>
-                <Navigation>Frontend::Agent</Navigation>
-                <Value>
-                        <Hash>
-                                <Item Key="URL">skins/Agent/otobo-dark-skin/img/your_logo.png</Item>
-                                <Item Key="StyleTop">16px</Item>
-                                <Item Key="StyleRight">24px</Item>
-                                <Item Key="StyleHeight">60px</Item>
-                                <Item Key="StyleWidth">194px</Item>
-                        </Hash>
-                </Value>
-        </Setting>
-        <Setting Name="Loader::Agent::Skin###001-otobo-dark-skin" Required="0" Valid="1">
-                <Description Translatable="1">OTOBO Dark Skin</Description>
-                <Navigation>Frontend::Base::Loader</Navigation>
-                <Value>
-                        <Hash>
-                                <Item Key="InternalName">otobo-dark-skin</Item>
-                                <Item Key="VisibleName" Translatable="1">OTOBO Dark Skin</Item>
-                                <Item Key="Description" Translatable="1">A dark skin for OTOBO</Item>
-                                <Item Key="HomePage">www.example.com</Item>
-                        </Hash>
-                </Value>
-        </Setting>
-</otobo_config>
-```
-Don't forget to adjust the logo and homepage parameters according to your needs.
-
-Now execute the following command as "otobo" user:
-```
-$OTOBO_HOME/bin/otobo.Console.pl Maint::Config::Rebuild
-```
-
-If you want this skin to be the default one for all new users, change the following system configuration setting to ```otobo-dark-skin```:
-```
+If you want this skin to be the default one for all new users, change the following system configuration setting to `OtoboDarkSkin`:
+``` 
 Loader::Agent::DefaultSelectedSkin
 ```
 
-Now you should be able to switch to this new skin in your personal settings.
+If you want to change the logo shown in the header of the agent interface, change the following system configuration setting:
+```
+AgentLogoCustom###OtoboDarkSkin
+```

--- a/var/httpd/htdocs/skins/Agent/OtoboDarkSkin/css/Core.Tooltip.css
+++ b/var/httpd/htdocs/skins/Agent/OtoboDarkSkin/css/Core.Tooltip.css
@@ -1,0 +1,26 @@
+/* OTOBO is a web-based ticketing system for service organisations.
+
+https://github.com/relkai/otobo-dark-skin
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @package     Skin "OtoboDarkSkin"
+ * @section     Tooltips
+ */
+
+@media screen,projection,tv,handheld {
+
+div.Tooltip > div.Content {
+    background-color: #1f1f1f;
+}    
+
+} /* end @media */


### PR DESCRIPTION
I updated the README to reference to the `OTOBO Package Manager` and `OTOBO System configuration`

@relkai Could you please review the description?


I also added a default value for `AgentLogoCustom###OtoboDarkSkin`. This is only a copy of `AgentLogoCustom###default` to enable a change of the logo in the  `OTOBO System configuration` based on the skin.


Other changes:
-	background color for Tooltip

